### PR TITLE
Added macro to include images into document, like in html5 asciidoc back...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ check:
 	git checkout gh-pages tutorial-slide.asciidoc
 	git checkout gh-pages example-template.asciidoc
 
-clean: 
+clean:
 	rm -rf example-template.html
 	rm -rf tutorial-slide.html
 	rm -rf deck.js.zip deck.js
@@ -80,6 +80,7 @@ clean:
 	rm -rf deckjs-*.zip
 	rm -rf deck.js-blank.zip
 	rm -rf deck.ext.js.zip
+	rm -rf deck.split.js.zip
 
 .PHONY: all clean test dist
 

--- a/deckjs.conf
+++ b/deckjs.conf
@@ -72,11 +72,11 @@ quote-style=template="quote_block",options=("a",)
 [image-blockmacro]
 # TODO use image block title for alt
 # <img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}" class="{incremental-option?slide }{incremental?slide}"/>
-<div class="imageblock{style? {style}}{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}{align? style="text-align:{align};"}{float? style="float:{float};"}>
+<div class="imageblock{style? {style}}{role? {role}}{unbreakable-option? unbreakable}{incremental-option? slide}{incremental? slide}"{id? id="{id}"}{align? style="text-align:{align};"}{float? style="float:{float};"}>
 <div class="content">
 <a class="image" href="{link}">
-{data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} class="{incremental-option?slide }{incremental?slide}">
-{data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} class="{incremental-option?slide }{incremental?slide}" src="data:image/{eval:os.path.splitext(r'{target}')[1][1:]};base64,
+{data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}>
+{data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} src="data:image/{eval:os.path.splitext(r'{target}')[1][1:]};base64,
 {data-uri#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </div>

--- a/deckjs.conf
+++ b/deckjs.conf
@@ -80,7 +80,7 @@ quote-style=template="quote_block",options=("a",)
 {data-uri#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </div>
-<div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>
+<div class="title" style="text-align: center">{caption={figure-caption} {counter:figure-number}. }{title}</div>
 </div>
 
 

--- a/deckjs.conf
+++ b/deckjs.conf
@@ -69,7 +69,17 @@ quote-style=template="quote_block",options=("a",)
 
 [image-blockmacro]
 # TODO use image block title for alt
-<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}" class="{incremental-option?slide }{incremental?slide}"/>
+# <img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}" class="{incremental-option?slide }{incremental?slide}"/>
+<div class="imageblock{style? {style}}{role? {role}}{unbreakable-option? unbreakable}"{id? id="{id}"}{align? style="text-align:{align};"}{float? style="float:{float};"}>
+<div class="content">
+<a class="image" href="{link}">
+{data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} class="{incremental-option?slide }{incremental?slide}">
+{data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} class="{incremental-option?slide }{incremental?slide}" src="data:image/{eval:os.path.splitext(r'{target}')[1][1:]};base64,
+{data-uri#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{link#}</a>
+</div>
+<div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>
+</div>
 
 
 #------------------------

--- a/deckjs.conf
+++ b/deckjs.conf
@@ -14,6 +14,8 @@ backend-deckjs=
 [macros]
 (?u)^(?P<name>video)::(?P<target>\S*?)(\[(?P<attrlist>.*?)\])$=#
 
+^>{3,}$=#nopagebreak
+
 [preamble]
 
 [sect1]
@@ -124,6 +126,15 @@ text=<p>|</p>
 |
 </div></div>
 
+#------------------------
+# for page break improvements. See slidy2 configuration file
+[nopagebreak-blockmacro]
+{set:slidepagebreak!}
+
+[pagebreak-blockmacro]
+{slidepagebreak}</div><div style="page-break-after:always"></div>
+# Set max-width here because Slidy ignores max-width on body.
+{set:slidepagebreak}
 
 
 [header]


### PR DESCRIPTION
With this mod no images folder is required. All images are directly into the html file, so you just need to copy the built .html to have all the slides with resources.
